### PR TITLE
feat: register Format Document provider via af fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Instead of relying on a large TextMate grammar, the extension starts the AgentFl
 - parser diagnostics surfaced directly in the editor
 - document symbols for prompt titles and variables
 - command-palette demo project scaffolding via `af demo init`
+- Format Document support powered by `af fmt`
 - bracket matching and auto-closing for AgentFlow tags
 
 The bundled TextMate grammar remains as a lightweight fallback while semantic tokens load, but the LSP is the primary source of language intelligence.
@@ -59,6 +60,12 @@ When those defaults are unchanged, the extension checks the active workspace's `
 If you set custom command or args values yourself, the extension respects them and skips auto-detection.
 
 You can also enable client tracing with `agentflow.languageServer.trace.server`.
+
+## Formatting
+
+Use VS Code's `Format Document` command in `.af` files to format templates with the AgentFlow CLI. The extension shells out to `af fmt` and applies the result as a single full-document edit, so formatter behavior stays aligned with the CLI.
+
+Formatter errors are written to the AgentFlow output channel without modifying the open document.
 
 ## Demo Projects
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -11,4 +11,14 @@ describe('extension manifest', () => {
       title: 'AgentFlow: Create Demo Project',
     })
   })
+
+  test('activates on AgentFlow documents for formatting support', () => {
+    expect(packageJson.activationEvents).toContain('onLanguage:agentflow')
+    expect(packageJson.contributes.languages).toContainEqual(
+      expect.objectContaining({
+        id: 'agentflow',
+        extensions: ['.af'],
+      }),
+    )
+  })
 })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode'
 import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { promisify } from 'node:util'
 import {
   Executable,
@@ -25,6 +28,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(outputChannel)
 
   context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider('agentflow', {
+      provideDocumentFormattingEdits: async document => formatDocument(document),
+    }),
     vscode.commands.registerCommand('agentflow.createDemoProject', async () => {
       await createDemoProject()
     }),
@@ -82,20 +88,73 @@ async function createDemoProject(): Promise<void> {
   }
 
   try {
-    await execFileAsync('af', ['demo', 'init', demoDir.fsPath])
+    await runAFCommand(['demo', 'init', demoDir.fsPath])
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
     if (isMissingExecutableError(error)) {
       vscode.window.showErrorMessage(`AgentFlow CLI not found on PATH. ${INSTALL_HINT}`)
       return
     }
 
-    vscode.window.showErrorMessage(`Failed to create AgentFlow demo project. ${message}`)
+    vscode.window.showErrorMessage(`Failed to create AgentFlow demo project. ${formatCommandError(error)}`)
     return
   }
 
   await vscode.commands.executeCommand('vscode.openFolder', demoDir, false)
   vscode.window.showInformationMessage('AgentFlow demo created. Next: run `af gen prompts --dir prompts`, then `go run .`.')
+}
+
+async function formatDocument(document: vscode.TextDocument): Promise<vscode.TextEdit[] | undefined> {
+  let tempDir: string | undefined
+
+  try {
+    let targetPath = document.uri.fsPath
+    if (document.uri.scheme !== 'file' || document.isDirty) {
+      tempDir = await mkdtemp(join(tmpdir(), 'agentflow-format-'))
+      targetPath = join(tempDir, 'document.af')
+      await writeFile(targetPath, document.getText(), 'utf8')
+    }
+
+    const { stdout } = await runAFCommand(['fmt', targetPath])
+    const fullRange = new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length))
+    return [vscode.TextEdit.replace(fullRange, stdout)]
+  } catch (error) {
+    if (isMissingExecutableError(error)) {
+      vscode.window.showErrorMessage(`AgentFlow CLI not found on PATH. ${INSTALL_HINT}`)
+      return undefined
+    }
+
+    outputChannel?.appendLine('AgentFlow formatter failed:')
+    outputChannel?.appendLine(formatCommandError(error))
+    outputChannel?.show(true)
+    return undefined
+  } finally {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+function runAFCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('af', args)
+}
+
+function formatCommandError(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return String(error)
+  }
+
+  const parts: string[] = []
+  if ('message' in error && typeof error.message === 'string' && error.message !== '') {
+    parts.push(error.message)
+  }
+  if ('stdout' in error && typeof error.stdout === 'string' && error.stdout !== '') {
+    parts.push(error.stdout.trimEnd())
+  }
+  if ('stderr' in error && typeof error.stderr === 'string' && error.stderr !== '') {
+    parts.push(error.stderr.trimEnd())
+  }
+
+  return parts.join('\n') || String(error)
 }
 
 function shouldStartLanguageServer(): boolean {


### PR DESCRIPTION
## Summary

- Register a VS Code `DocumentFormattingEditProvider` for AgentFlow documents.
- Shell out to `af fmt` for saved files and temp-file copies of dirty or untitled documents, keeping the CLI formatter as the single source of truth.
- Apply formatter output as a single full-document replacement edit and report formatter errors in the AgentFlow output channel without mutating the document.
- Reuse the existing ENOENT install hint path and document the formatting workflow.

Closes #11.

## Tests

- `bun run compile`
- `bun test src/extension.test.ts`
- `bunx vsce package --out /tmp/agentflow-vscode-ci.vsix`
