### PR TITLE
feat: surface af lint diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Instead of relying on a large TextMate grammar, the extension starts the AgentFl
 - document symbols for prompt titles and variables
 - command-palette demo project scaffolding via `af demo init`
 - Format Document support powered by `af fmt`
+- inline diagnostics powered by `af lint --format json`
 - bracket matching and auto-closing for AgentFlow tags
 
 The bundled TextMate grammar remains as a lightweight fallback while semantic tokens load, but the LSP is the primary source of language intelligence.
@@ -66,6 +67,10 @@ You can also enable client tracing with `agentflow.languageServer.trace.server`.
 Use VS Code's `Format Document` command in `.af` files to format templates with the AgentFlow CLI. The extension shells out to `af fmt` and applies the result as a single full-document edit, so formatter behavior stays aligned with the CLI.
 
 Formatter errors are written to the AgentFlow output channel without modifying the open document.
+
+## Diagnostics
+
+AgentFlow files are linted with `af lint --format json` on open, save, and debounced edits. Diagnostics are displayed inline in VS Code and use the same rules as the CLI linter.
 
 ## Demo Projects
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -21,4 +21,8 @@ describe('extension manifest', () => {
       }),
     )
   })
+
+  test('activates on AgentFlow documents for lint diagnostics', () => {
+    expect(packageJson.activationEvents).toContain('onLanguage:agentflow')
+  })
 })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,13 +19,27 @@ const GO_TOOL_COMMAND = 'go'
 const GO_TOOL_ARGS = ['tool', 'af', 'lsp', '--mode', 'stdio']
 const AGENTFLOW_TOOL_MODULE = 'github.com/omniaura/agentflow/cmd/af'
 const INSTALL_HINT = 'Install AgentFlow with: go install github.com/omniaura/agentflow/cmd/af@latest'
+const LINT_DEBOUNCE_MS = 300
 
 let client: LanguageClient | undefined
 let outputChannel: vscode.OutputChannel | undefined
+let diagnosticCollection: vscode.DiagnosticCollection | undefined
+const lintTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+type AgentFlowDiagnostic = {
+  file: string
+  line: number
+  column: number
+  severity: 'error' | 'warning'
+  code: string
+  message: string
+}
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   outputChannel = vscode.window.createOutputChannel('AgentFlow Language Server')
+  diagnosticCollection = vscode.languages.createDiagnosticCollection('agentflow')
   context.subscriptions.push(outputChannel)
+  context.subscriptions.push(diagnosticCollection)
 
   context.subscriptions.push(
     vscode.languages.registerDocumentFormattingEditProvider('agentflow', {
@@ -47,11 +61,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (document.uri.scheme === 'file' && document.fileName.endsWith('go.mod')) {
         await restartLanguageServer(context)
       }
+      scheduleLint(document)
+    }),
+    vscode.workspace.onDidOpenTextDocument(document => {
+      scheduleLint(document)
+    }),
+    vscode.workspace.onDidChangeTextDocument(event => {
+      scheduleLint(event.document)
+    }),
+    vscode.workspace.onDidCloseTextDocument(document => {
+      clearLintTimer(document)
+      diagnosticCollection?.delete(document.uri)
     }),
     vscode.workspace.onDidChangeWorkspaceFolders(async () => {
       await restartLanguageServer(context)
     }),
   )
+
+  for (const document of vscode.workspace.textDocuments) {
+    scheduleLint(document)
+  }
 
   if (shouldStartLanguageServer()) {
     await startLanguageServer(context)
@@ -134,6 +163,80 @@ async function formatDocument(document: vscode.TextDocument): Promise<vscode.Tex
   }
 }
 
+function scheduleLint(document: vscode.TextDocument): void {
+  if (document.languageId !== 'agentflow') {
+    return
+  }
+
+  clearLintTimer(document)
+  const key = document.uri.toString()
+  lintTimers.set(key, setTimeout(() => {
+    lintTimers.delete(key)
+    void lintDocument(document)
+  }, LINT_DEBOUNCE_MS))
+}
+
+function clearLintTimer(document: vscode.TextDocument): void {
+  const key = document.uri.toString()
+  const timer = lintTimers.get(key)
+  if (timer) {
+    clearTimeout(timer)
+    lintTimers.delete(key)
+  }
+}
+
+async function lintDocument(document: vscode.TextDocument): Promise<void> {
+  let tempDir: string | undefined
+
+  try {
+    let targetPath = document.uri.fsPath
+    if (document.uri.scheme !== 'file' || document.isDirty) {
+      tempDir = await mkdtemp(join(tmpdir(), 'agentflow-lint-'))
+      targetPath = join(tempDir, 'document.af')
+      await writeFile(targetPath, document.getText(), 'utf8')
+    }
+
+    const { stdout } = await runAFCommand(['lint', '--format', 'json', targetPath])
+    diagnosticCollection?.set(document.uri, parseLintDiagnostics(document, stdout))
+  } catch (error) {
+    if (isMissingExecutableError(error)) {
+      diagnosticCollection?.delete(document.uri)
+      return
+    }
+
+    const stdout = getCommandStdout(error)
+    if (stdout) {
+      diagnosticCollection?.set(document.uri, parseLintDiagnostics(document, stdout))
+      return
+    }
+
+    outputChannel?.appendLine('AgentFlow lint failed:')
+    outputChannel?.appendLine(formatCommandError(error))
+    outputChannel?.show(true)
+  } finally {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  }
+}
+
+function parseLintDiagnostics(document: vscode.TextDocument, raw: string): vscode.Diagnostic[] {
+  const parsed = JSON.parse(raw) as AgentFlowDiagnostic[]
+  return parsed.map(diagnostic => {
+    const line = Math.max(diagnostic.line - 1, 0)
+    const column = Math.max(diagnostic.column - 1, 0)
+    const start = new vscode.Position(line, column)
+    const lineText = document.lineAt(Math.min(line, document.lineCount - 1)).text
+    const endColumn = Math.min(Math.max(column + 1, column), lineText.length)
+    const range = new vscode.Range(start, new vscode.Position(line, endColumn))
+    const severity = diagnostic.severity === 'error' ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning
+    const vscodeDiagnostic = new vscode.Diagnostic(range, diagnostic.message, severity)
+    vscodeDiagnostic.code = diagnostic.code
+    vscodeDiagnostic.source = 'af lint'
+    return vscodeDiagnostic
+  })
+}
+
 function runAFCommand(args: string[]): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync('af', args)
 }
@@ -155,6 +258,13 @@ function formatCommandError(error: unknown): string {
   }
 
   return parts.join('\n') || String(error)
+}
+
+function getCommandStdout(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'stdout' in error && typeof error.stdout === 'string' && error.stdout !== '') {
+    return error.stdout
+  }
+  return undefined
 }
 
 function shouldStartLanguageServer(): boolean {


### PR DESCRIPTION
## Summary

- Add a single AgentFlow `DiagnosticCollection` populated by `af lint --format json`.
- Lint AgentFlow documents on open, save, and debounced edits, using temp files for dirty or untitled documents.
- Map CLI error/warning diagnostics into VS Code diagnostics while keeping the CLI linter as the single source of truth.
- Document inline diagnostics in the README and extend the manifest contract test.

Closes #14.

## Tests

- `bun run compile`
- `bun test src/extension.test.ts`
- `bunx vsce package --out /tmp/agentflow-vscode-ci.vsix`
